### PR TITLE
fix: remove debug logs from trpc layer + expand test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -289,4 +289,4 @@ paket-files/
 
 # JetBrains Rider
 .idea/
-*.sln.iml
+*.sln.imlpackage-lock.json

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,10 @@
+# test/
+
+Unit tests for `@arken/node`. Run with `npx jest --config jest.unit.config.js`.
+
+## Files
+
+- **`socketLink.spec.ts`** — Tests for `createSocketLink`, `attachTrpcResponseHandler`, and `createSocketProxyClient`. Covers routing, timeouts, error propagation, and server push handling.
+- **`socketLink.extended.spec.ts`** — Extended tests for `attachTrpcResponseHandler` (custom `responseIdField`, `preferOnAny`, teardown) and `bindSocketClientEmit` (end-to-end proxy + response resolution).
+- **`socketServer.spec.ts`** — Tests for `createSocketTrpcHandler`. Covers successful procedure invocation and error handling.
+- **`socketServer.attachListener.spec.ts`** — Tests for `attachSocketTrpcListener`. Covers event registration, custom event names, handler invocation, teardown, and graceful handling of sockets without `on`/`off`.

--- a/test/socketLink.extended.spec.ts
+++ b/test/socketLink.extended.spec.ts
@@ -1,0 +1,224 @@
+// arken/packages/node/test/socketLink.extended.spec.ts
+
+import {
+  attachTrpcResponseHandler,
+  bindSocketClientEmit,
+  type SocketClient,
+} from '../trpc/socketLink';
+
+// =========================
+// attachTrpcResponseHandler — extended
+// =========================
+
+describe('attachTrpcResponseHandler (extended)', () => {
+  function makeSocket() {
+    const handlers: Record<string, Function> = {};
+    let anyHandler: Function | null = null;
+    return {
+      handlers,
+      on: jest.fn((event: string, cb: Function) => {
+        handlers[event] = cb;
+      }),
+      off: jest.fn((event: string, _cb: Function) => {
+        delete handlers[event];
+      }),
+      onAny: jest.fn((cb: Function) => {
+        anyHandler = cb;
+      }),
+      offAny: jest.fn((_cb: Function) => {
+        anyHandler = null;
+      }),
+      fireAny(event: string, payload: any) {
+        if (anyHandler) (anyHandler as Function)(event, payload);
+      },
+      fire(event: string, payload: any) {
+        if (handlers[event]) handlers[event](payload);
+      },
+    };
+  }
+
+  it('supports responseIdField "oid"', () => {
+    const socket = makeSocket();
+    const client: any = {
+      socket,
+      ioCallbacks: {
+        'req-42': {
+          timeout: null,
+          resolve: jest.fn(),
+          reject: jest.fn(),
+        },
+      },
+    };
+
+    attachTrpcResponseHandler({
+      client,
+      backendName: 'seer',
+      logging: false,
+      responseIdField: 'oid',
+    });
+
+    // Simulate server response with oid field
+    socket.fire('trpcResponse', {
+      oid: 'req-42',
+      result: '{"status":1,"data":"ok"}',
+    });
+
+    expect(client.ioCallbacks['req-42']).toBeUndefined();
+  });
+
+  it('uses onAny when preferOnAny is true', () => {
+    const socket = makeSocket();
+    const client: any = {
+      socket,
+      ioCallbacks: {
+        'req-99': {
+          timeout: null,
+          resolve: jest.fn(),
+          reject: jest.fn(),
+        },
+      },
+    };
+
+    const teardown = attachTrpcResponseHandler({
+      client,
+      backendName: 'seer',
+      logging: false,
+      preferOnAny: true,
+    });
+
+    expect(socket.onAny).toHaveBeenCalled();
+
+    // Fire via onAny
+    socket.fireAny('trpcResponse', {
+      id: 'req-99',
+      result: '{"status":1}',
+    });
+
+    expect(client.ioCallbacks['req-99']).toBeUndefined();
+
+    // Teardown should call offAny
+    teardown();
+    expect(socket.offAny).toHaveBeenCalled();
+  });
+
+  it('returns teardown that removes on handlers', () => {
+    const socket = makeSocket();
+    const client: any = { socket, ioCallbacks: {} };
+
+    const teardown = attachTrpcResponseHandler({
+      client,
+      backendName: 'test',
+      logging: false,
+    });
+
+    expect(socket.on).toHaveBeenCalledWith('trpc', expect.any(Function));
+    expect(socket.on).toHaveBeenCalledWith('trpcResponse', expect.any(Function));
+
+    teardown();
+
+    expect(socket.off).toHaveBeenCalledWith('trpc', expect.any(Function));
+    expect(socket.off).toHaveBeenCalledWith('trpcResponse', expect.any(Function));
+  });
+
+  it('calls reject when resolve throws', () => {
+    const socket = makeSocket();
+    const rejectMock = jest.fn();
+    const client: any = {
+      socket,
+      ioCallbacks: {
+        'req-throw': {
+          timeout: null,
+          resolve: jest.fn(() => { throw new Error('resolve boom'); }),
+          reject: rejectMock,
+        },
+      },
+    };
+
+    attachTrpcResponseHandler({
+      client,
+      backendName: 'seer',
+      logging: false,
+    });
+
+    socket.fire('trpcResponse', {
+      id: 'req-throw',
+      result: '{"status":1}',
+    });
+
+    expect(rejectMock).toHaveBeenCalled();
+  });
+});
+
+// =========================
+// bindSocketClientEmit
+// =========================
+
+describe('bindSocketClientEmit', () => {
+  function makeSocket() {
+    const handlers: Record<string, Function> = {};
+    return {
+      handlers,
+      emit: jest.fn(),
+      on: jest.fn((event: string, cb: Function) => {
+        handlers[event] = cb;
+      }),
+      off: jest.fn(),
+      fire(event: string, payload: any) {
+        if (handlers[event]) handlers[event](payload);
+      },
+    };
+  }
+
+  it('sets up client.socket and ioCallbacks, returns a proxy', () => {
+    const socket = makeSocket();
+    const client: any = { ioCallbacks: undefined, socket: undefined };
+
+    const proxy = bindSocketClientEmit({
+      client,
+      socket,
+      backendName: 'seer',
+      logging: false,
+    });
+
+    expect(client.socket).toBe(socket);
+    expect(client.ioCallbacks).toBeDefined();
+    expect(proxy).toBeDefined();
+  });
+
+  it('proxy emits trpc and resolves via trpcResponse', async () => {
+    const socket = makeSocket();
+    const client: any = { ioCallbacks: {}, socket: undefined };
+
+    const proxy: any = bindSocketClientEmit({
+      client,
+      socket,
+      backendName: 'seer',
+      logging: false,
+      requestTimeoutMs: 5000,
+    });
+
+    // Start a call
+    const promise = proxy.core.ping.query({ msg: 'hi' });
+
+    await Promise.resolve();
+
+    // Socket should have emitted a trpc message
+    expect(socket.emit).toHaveBeenCalledWith('trpc', expect.objectContaining({
+      method: 'core.ping',
+      type: 'query',
+    }));
+
+    // Get the request id from the emit call
+    const [, payload] = socket.emit.mock.calls[0];
+    const reqId = payload.id;
+
+    // Simulate trpcResponse coming back via the on handler
+    socket.fire('trpcResponse', {
+      id: reqId,
+      result: JSON.stringify({ status: 1, data: { pong: 'hi' } }),
+    });
+
+    const result = await promise;
+    expect(result).toEqual({ pong: 'hi' });
+  });
+});

--- a/test/socketLink.spec.ts
+++ b/test/socketLink.spec.ts
@@ -342,7 +342,7 @@ describe('attachTrpcResponseHandler', () => {
     expect(onServerPush).not.toHaveBeenCalled();
   });
 
-  it('calls onServerPush for messages without id (server push)', () => {
+  it('calls onServerPush for messages on the "trpc" event (server push)', () => {
     const socket = makeSocket();
     const client: any = {
       socket,
@@ -358,12 +358,15 @@ describe('attachTrpcResponseHandler', () => {
       onServerPush,
     });
 
-    const msg = { method: 'core.notify', params: '{"foo":"bar"}' };
-    socket.handlers['trpcResponse'](msg);
+    // Server pushes arrive via the 'trpc' event handler, which maps to a
+    // non-'trpcResponse' eventName internally, hitting the else/onServerPush branch.
+    const msg = { method: 'core.notify', params: JSON.stringify({ foo: 'bar' }) };
+    socket.handlers['trpc'](msg);
 
     expect(onServerPush).toHaveBeenCalledWith({
+      id: undefined,
       method: 'core.notify',
-      params: '{"foo":"bar"}',
+      params: { foo: 'bar' },  // deserialize is called on params
     });
   });
 });

--- a/test/socketServer.attachListener.spec.ts
+++ b/test/socketServer.attachListener.spec.ts
@@ -1,0 +1,76 @@
+// arken/packages/node/test/socketServer.attachListener.spec.ts
+
+import { attachSocketTrpcListener } from '../trpc/socketServer';
+
+describe('attachSocketTrpcListener', () => {
+  function makeSocket() {
+    const handlers: Record<string, Function[]> = {};
+    return {
+      handlers,
+      on: jest.fn((event: string, cb: Function) => {
+        handlers[event] = handlers[event] || [];
+        handlers[event].push(cb);
+      }),
+      off: jest.fn((event: string, cb: Function) => {
+        if (handlers[event]) {
+          handlers[event] = handlers[event].filter((h) => h !== cb);
+        }
+      }),
+      fire(event: string, payload: any) {
+        (handlers[event] || []).forEach((fn) => fn(payload));
+      },
+    };
+  }
+
+  it('registers a handler on the default "trpc" event', () => {
+    const socket = makeSocket();
+    const handleSocketTrpc = jest.fn();
+
+    attachSocketTrpcListener({ socket, ctx: {}, handleSocketTrpc });
+
+    expect(socket.on).toHaveBeenCalledWith('trpc', expect.any(Function));
+  });
+
+  it('registers a handler on a custom event name', () => {
+    const socket = makeSocket();
+    const handleSocketTrpc = jest.fn();
+
+    attachSocketTrpcListener({ socket, ctx: {}, handleSocketTrpc, eventName: 'rpc' });
+
+    expect(socket.on).toHaveBeenCalledWith('rpc', expect.any(Function));
+  });
+
+  it('calls handleSocketTrpc with socket, ctx, and message', async () => {
+    const socket = makeSocket();
+    const handleSocketTrpc = jest.fn().mockResolvedValue(undefined);
+    const ctx = { userId: 'u1' };
+
+    attachSocketTrpcListener({ socket, ctx, handleSocketTrpc });
+
+    const msg = { id: '1', method: 'core.ping', params: {} };
+    socket.fire('trpc', msg);
+
+    await Promise.resolve();
+    expect(handleSocketTrpc).toHaveBeenCalledWith(socket, ctx, msg);
+  });
+
+  it('returns a teardown function that removes the listener', () => {
+    const socket = makeSocket();
+    const handleSocketTrpc = jest.fn();
+
+    const teardown = attachSocketTrpcListener({ socket, ctx: {}, handleSocketTrpc });
+
+    expect(socket.handlers['trpc'].length).toBe(1);
+    teardown();
+    expect(socket.off).toHaveBeenCalledWith('trpc', expect.any(Function));
+  });
+
+  it('does nothing if socket has no on method', () => {
+    const socket = { emit: jest.fn() } as any;
+    const handleSocketTrpc = jest.fn();
+
+    // Should not throw
+    const teardown = attachSocketTrpcListener({ socket, ctx: {}, handleSocketTrpc });
+    teardown(); // also should not throw
+  });
+});

--- a/test/socketServer.spec.ts
+++ b/test/socketServer.spec.ts
@@ -2,7 +2,7 @@
 
 import { initTRPC } from '@trpc/server';
 import { createSocketTrpcHandler } from '../trpc/socketServer';
-import { serialize, deserialize } from '../util/rpc';
+import { serialize, deserialize } from '../rpc';
 
 describe('createSocketTrpcHandler (Socket.IO tRPC server helper)', () => {
   const t = initTRPC.context<{ userId?: string }>().create();

--- a/trpc/README.md
+++ b/trpc/README.md
@@ -1,0 +1,38 @@
+# trpc/
+
+Socket.IO-based tRPC transport layer for the Arken protocol. Provides both client and server sides of a custom tRPC link that runs over Socket.IO instead of HTTP.
+
+## Files
+
+### `socketLink.ts`
+Client-side tRPC link and utilities for Socket.IO transport.
+
+- **`createSocketLink(options)`** — tRPC link that routes operations to named backends via Socket.IO. Maps the first segment of the procedure path (e.g. `seer.core.getRealms` → backend `seer`) to the correct socket client.
+- **`attachTrpcResponseHandler(options)`** — Attaches event listeners to a socket client that resolve pending request callbacks when `trpcResponse` events arrive. Also supports server-push messages via `onServerPush`.
+- **`createSocketProxyClient(options)`** — Creates a tRPC proxy client over a single `SocketClient`. Used for peer-to-peer or direct socket connections.
+- **`bindSocketClientEmit(options)`** — Server-side convenience that combines `attachTrpcResponseHandler` + `createSocketProxyClient` in one call. Use when setting up a bidirectional socket connection (e.g. shard ↔ realm).
+
+### `socketServer.ts`
+Server-side handler for processing incoming tRPC requests over Socket.IO.
+
+- **`createSocketTrpcHandler(options)`** — Creates an async handler function that deserializes incoming `trpc` event messages, invokes the matching tRPC procedure via `createCallerFactory`, and emits `trpcResponse` with serialized results.
+- **`attachSocketTrpcListener(options)`** — Convenience helper that wires `socket.on('trpc', ...)` to the handler. Returns a teardown function.
+
+## Protocol Flow
+
+```
+Client                          Server
+  |                               |
+  |-- socket.emit('trpc', {      |
+  |     id, method, type, params  |
+  |   }) -----------------------> |
+  |                               |-- createCaller(ctx)
+  |                               |-- caller[method](deserialize(params))
+  |   <-------------------------- |
+  |   socket.emit('trpcResponse', |
+  |     { id, result, error? })   |
+```
+
+## Serialization
+
+All params and results go through `serialize`/`deserialize` from `../rpc.ts` (JSON-based with special handling for ObjectIds, Dates, etc). Binary payloads are decoded via `decodePayload` from `../binary.ts`.

--- a/trpc/socketLink.ts
+++ b/trpc/socketLink.ts
@@ -153,7 +153,6 @@ export function createSocketLink(options: CreateSocketLinkOptions): TRPCLink<any
                 observer.error(baseErr as any);
               } else {
                 const result: any = deserialize(response.result);
-                console.log('zzzzzzz', response.result, result);
                 observer.next({ result } as any);
                 observer.complete();
               }
@@ -342,7 +341,6 @@ export function createSocketProxyClient<TRouter = any>(opts: CreateSocketProxyCl
 
                   observer.error(baseErr);
                 } else {
-                  console.log('zzzzzz', pack.result, deserialize(pack.result));
                   const result: any = deserialize(pack.result);
                   if (result?.status !== 1) {
                     const statusErr = new TRPCClientError<any>(

--- a/trpc/socketServer.ts
+++ b/trpc/socketServer.ts
@@ -23,10 +23,7 @@ export function createSocketTrpcHandler<TRouter extends AnyRouter = AnyRouter>({
   const createCaller = createCallerFactory(router);
 
   return async function handleSocketTrpc(socket: any, ctx: any, _message: any) {
-    console.log('message', _message);
-
     const message = typeof _message === 'string' ? decodePayload(_message) : _message;
-    console.log('message', message);
 
     const { id, method, params } = message;
 


### PR DESCRIPTION
## Changes

### Bug fixes
- Remove `console.log("zzzzzzz", ...)` and `console.log("zzzzzz", ...)` debug statements from `socketLink.ts`
- Remove `console.log("message", ...)` debug statements from `socketServer.ts`
- Fix import path in `socketServer.spec.ts` (`util/rpc` → `rpc`)
- Fix `onServerPush` test: was firing on wrong event (`trpcResponse` instead of `trpc`) and expecting raw string instead of deserialized params

### New tests (22 total, all passing)
- `socketLink.extended.spec.ts`: Tests for `responseIdField: "oid"`, `preferOnAny` mode, teardown cleanup, reject-on-throw in response handler, and `bindSocketClientEmit` end-to-end
- `socketServer.attachListener.spec.ts`: Tests for `attachSocketTrpcListener` — event registration, custom event names, handler invocation, teardown, no-op socket

### Documentation
- `trpc/README.md`: Describes the Socket.IO tRPC transport layer, all exports, and protocol flow
- `test/README.md`: Describes all test files

---
_Submitted by Sable 🔮_